### PR TITLE
Adding the option for users to trigger a reboot at the end of the script

### DIFF
--- a/ubuntu-debullshit.sh
+++ b/ubuntu-debullshit.sh
@@ -87,6 +87,27 @@ echo '                           _
  '
 }
 
+reboot_yes_no() {
+  while true; do
+    read -p "Do you want to reboot now? [y/n]: " yn
+    yn=$(echo $yn | tr '[:upper:]' '[:lower:]') # convert input to lowercase
+    case $yn in
+      yes|y)
+        echo "Rebooting, please wait..."
+        sudo shutdown -r
+        break
+        ;;
+      no|n)
+        echo "Enjoy! :)"
+        break
+        ;;
+      *)
+        echo "Please answer yes or no."
+        ;;
+    esac
+  done
+}
+
 main() {
 	print_banner
 	check_normal_user
@@ -109,6 +130,7 @@ main() {
 	msg 'Cleaning up'
 	cleanup
 	msg 'Reboot now to finish installation'
+	reboot_yes_no
 }
 
 main

--- a/ubuntu-debullshit.sh
+++ b/ubuntu-debullshit.sh
@@ -72,6 +72,7 @@ check_normal_user() {
 		echo It will prompt you for password when necessary
 		exit
 	fi
+	msg 'This script requires elevated privileges to run some commands:'
 	sudo -k
 	sudo true
 }


### PR DESCRIPTION
Very small QoL improvement to prompt users at the end of the script if they would like to reboot or not, using shutdown to make it as graceful as possible. It'll accept "yes", "no", "y" or "n" regardless of case. 

Snuck in one extra commit to _maybe_ satisfy some people in the reddit comments complaining about sudo, just a single line that will appear prior to the sudo password prompt explaining why we're asking for it. 

Tested on 22.04, and 23.04 VM's. 